### PR TITLE
Fixing Link to example gist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 >> This is an alpha release
 
-A GUI that wants to make data profiling beautiful. You can read any json with this schema https://gist.github.com/argenisleon/f3989cc61da28a6cedcf5c77e5942888/edit and bumblebee will plot frecuency and histograms charts to better help you make sense of your data.
+A GUI that wants to make data profiling beautiful. You can read any json with this schema https://gist.github.com/argenisleon/f3989cc61da28a6cedcf5c77e5942888 and bumblebee will plot frecuency and histograms charts to better help you make sense of your data.
 
 ## Blublebee is Agnostic 
 You can output this json from whatever software or library you want, for example R or Pandas(Python) and use it with Bumblebee.


### PR DESCRIPTION
The suffix `/edit` causes a 404 error for normal users.